### PR TITLE
Add Travis CI build and deployment to DockerHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+services:
+  - docker
+
+script: ./travis/build_docker.sh
+
+branches:
+  only:
+  - master

--- a/travis/build_docker.sh
+++ b/travis/build_docker.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -xe
+# Script for building and pushing Frontier Squid docker images
+
+org='opensciencegrid'
+timestamp=`date +%Y%m%d-%H%M`
+docker_repos='frontier-squid'
+
+for repo in $docker_repos; do
+    docker build \
+           -t $org/$repo:development \
+           -t $org/$repo:$timestamp \
+           $repo
+done
+
+if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]]; then
+    echo "DockerHub deployment not performed for pull requests"
+    exit 0
+fi
+
+# Credentials for docker push
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
+for repo in $docker_repos; do
+    for tag in $timestamp development; do
+        docker push $org/$repo:$tag
+    done
+done

--- a/travis/build_docker.sh
+++ b/travis/build_docker.sh
@@ -9,7 +9,7 @@ for repo in $docker_repos; do
     docker build \
            -t $org/$repo:development \
            -t $org/$repo:$timestamp \
-           $repo
+           .
 done
 
 if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]]; then


### PR DESCRIPTION
This is how we're currently doing the docker hub deployment:

1. Set up docker hub repository
2. Give `robots` write permission
3. Enable Travis CI for the GitHub repo
4. Add `DOCKER_USERNAME` and `DOCKER_PASSWORD` as Travis CI protected env vars

I think there's a lot that can be improved about the process here. Perhaps having a central git repository that has the sensitive info and does all the pushing? Or if we want to keep things separate, the common parts of the build/push scripts can be factored out into an RPM or git submodule (ehhhh).