### PR TITLE
Install frontier-squid from osg-development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN useradd -o -u 10941 -g 10941 -s /sbin/nologin -d /var/lib/squid squid
 RUN yum clean all && \
     yum update -y 
 
-RUN yum install -y frontier-squid
+RUN yum install -y frontier-squid --enablerepo=osg-development
 
 RUN yum clean all --enablerepo=* && rm -rf /var/cache/yum/
 


### PR DESCRIPTION
From our [container release policy](https://opensciencegrid.org/technology/policy/container-release/):

> Additionally, container images distributed by the OSG Software team will be based off of the latest version of a [supported platform](https://opensciencegrid.org/docs/release/supported_platforms/) with software installed from OS, EPEL, and OSG release Yum repositories with select packages installed from `osg-development`.