### PR TITLE
add dispatched github action workflow (SOFTWARE-4172)

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -6,7 +6,7 @@ on:
       - dispatch-build
 
 jobs:
-  dispatched-build:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -30,4 +30,3 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: opensciencegrid/docker-frontier-squid
         tags: fresh,${{ steps.mkdatetag.outputs.dtag }}
-

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,6 +1,9 @@
 name: dispatched build-docker-image
 
 on:
+  push:
+    branches:
+      - master
   repository_dispatch:
     types:
       - dispatch-build

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -14,11 +14,6 @@ jobs:
     - name: checkout frontier-squid
       uses: actions/checkout@v2
 
-#     with:
-#       ref: ${{ github.event.client_payload.ref }}
-#
-#   - run: echo ${{ github.event.client_payload.sha }}
-
     - name: make date tag
       id: mkdatetag
       run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,0 +1,33 @@
+name: dispatched build-docker-image
+
+on:
+  repository_dispatch:
+    types:
+      - dispatch-build
+
+jobs:
+  dispatched-build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: checkout frontier-squid
+      uses: actions/checkout@v2
+
+#     with:
+#       ref: ${{ github.event.client_payload.ref }}
+#
+#   - run: echo ${{ github.event.client_payload.sha }}
+
+    - name: make date tag
+      id: mkdatetag
+      run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
+
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: opensciencegrid/docker-frontier-squid
+        tags: fresh,${{ steps.mkdatetag.outputs.dtag }}
+


### PR DESCRIPTION
I get the impression that we don't actually want to use the `with: ref: ...` thing for the checkout, since the `ref` and `sha` parameter passed in refer to the software-base repo ... I think.