### PR TITLE
Fix bash syntax error

### DIFF
--- a/squid-customize.sh
+++ b/squid-customize.sh
@@ -27,7 +27,7 @@ if [ -z "$SQUID_CACHE_DISK" ]; then
   exit 1
 fi
 
-if [-z "$SQUID_CACHE_DISK_LOCATION" ]; then
+if [ -z "$SQUID_CACHE_DISK_LOCATION" ]; then
   echo "ERROR: SQUID_CACHE_DISK_LOCATION undefined, aborting" 1>&2
   exit 1
 fi


### PR DESCRIPTION
Fix a bash syntax error in squid-customize.sh.  It was [committed 7 months ago](https://github.com/opensciencegrid/docker-frontier-squid/blame/master/squid-customize.sh#L30) and I'm not sure how it has lasted this long.