### PR TITLE
Publish dev, testing, and release images (SOFTWARE-4457)

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,31 +1,56 @@
-name: dispatched build-docker-image
+name: Build and Push Docker image
 
 on:
   push:
-    branches:
-      - master
+    branches: [ master ]
   repository_dispatch:
     types:
       - dispatch-build
 
 jobs:
-  build:
+  make-date-tag:
     runs-on: ubuntu-latest
-    if: github.repository == 'opensciencegrid/docker-frontier-squid'
+    if: startsWith(github.repository, 'opensciencegrid/')
+    outputs:
+      dtag: ${{ steps.mkdatetag.outputs.dtag }}
     steps:
-
-    - name: checkout frontier-squid
-      uses: actions/checkout@v2
-
     - name: make date tag
       id: mkdatetag
       run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
 
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v1
+  build:
+    runs-on: ubuntu-latest
+    needs: [make-date-tag]
+    if: startsWith(github.repository, 'opensciencegrid/')
+    strategy:
+      fail-fast: False
+      matrix:
+        repo: ['development', 'testing', 'release']
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Generate tag list
+      id: generate-tag-list
+      env:
+        REPO: ${{ matrix.repo }}
+        TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
+      run: |
+        docker_repo=${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}
+        tag_list=$docker_repo:$REPO,$docker_repo:$REPO-$TIMESTAMP
+        echo "::set-output name=taglist::$tag_list"
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: opensciencegrid/frontier-squid
-        build_args: SW_BASE_TAG=el8-fresh
-        tags: fresh, ${{ steps.mkdatetag.outputs.dtag }}
+
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v2.2.0
+      with:
+        push: true
+        build-args: BASE_YUM_REPO=${{ matrix.repo }}
+        tags: "${{ steps.generate-tag-list.outputs.taglist }}"

--- a/.github/workflows/build-fresh-container.yml
+++ b/.github/workflows/build-fresh-container.yml
@@ -1,0 +1,31 @@
+name: dispatched build-docker-image
+
+on:
+  push:
+    branches:
+      - master
+  repository_dispatch:
+    types:
+      - dispatch-build
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.repository == 'opensciencegrid/docker-frontier-squid'
+    steps:
+
+    - name: checkout frontier-squid
+      uses: actions/checkout@v2
+
+    - name: make date tag
+      id: mkdatetag
+      run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
+
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: opensciencegrid/frontier-squid
+        build_args: SW_BASE_TAG=el8-fresh
+        tags: fresh, ${{ steps.mkdatetag.outputs.dtag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Specify the opensciencegrid/software-base image tag
-ARG SW_BASE_TAG=fresh
+ARG YUM_BASE_REPO=testing
 
-FROM opensciencegrid/software-base:$SW_BASE_TAG
+FROM opensciencegrid/software-base:el8-$YUM_BASE_REPO
 
 LABEL maintainer OSG Software <help@opensciencegrid.org>
 
@@ -11,7 +11,7 @@ LABEL maintainer OSG Software <help@opensciencegrid.org>
 RUN groupadd -o -g 10941 squid && \
     useradd -o -u 10941 -g 10941 -s /sbin/nologin -d /var/lib/squid squid && \
     yum update -y && \
-    yum install -y frontier-squid --enablerepo=osg-testing && \
+    yum install -y frontier-squid && \
     rm -rf /var/cache/yum/* && \
     mkdir /etc/squid/customize.d
 


### PR DESCRIPTION
FYI @sfiligoi @ddavila0 @Mansalu @LincolnBryant @DrDaveD : this is to add new image tags for the new OSG container tagging policy: https://github.com/opensciencegrid/technology/blob/227362f60fa119e5b468c7ccb64496d7daf84e10/docs/policy/container-release.md

This PR also moves `fresh` image generation until consumers are ready to move to the new tags. The `Dockerfile` changes don't obviously work with the old `fresh` build/tagging workflow but it works by virtue of `software-base:el8-fresh` being the same as `software-base:el8-testing`

