### PR TITLE
Support stopping and restarting with supervisorctl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN groupadd -o -g 10941 squid && \
     mkdir /etc/squid/customize.d
 
 COPY 60-image-post-init.sh /etc/osg/image-config.d/60-image-post-init.sh
+COPY start-frontier-squid.sh /usr/sbin/
 COPY squid-customize.sh /etc/squid/customize.sh
 COPY customize.d/* /etc/squid/customize.d/
 COPY supervisor-frontier-squid.conf /etc/supervisord.d/40-frontier-squid.conf

--- a/start-frontier-squid.sh
+++ b/start-frontier-squid.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Wrapper script for starting & stopping frontier squid from supervisord
+
+# stop squid if supervisord sends a TERM signal
+trap "/usr/sbin/fn-local-squid.sh stop" TERM
+
+# we tell squid to run in the foreground, but by telling the
+#   shell to start it in the background and waiting for it we
+#   prevent the shell from ignoring signals
+export SQUID_START_ARGS="--foreground"
+/usr/sbin/fn-local-squid.sh start &
+wait

--- a/supervisor-frontier-squid.conf
+++ b/supervisor-frontier-squid.conf
@@ -1,6 +1,4 @@
 [program:frontier-squid]
-environment=SQUID_START_ARGS="--foreground"
-command=/usr/sbin/fn-local-squid.sh start
-stopwaitsecs=45
+command=/usr/sbin/start-frontier-squid.sh
+stopwaitsecs=90
 user=squid
-autorestart=true


### PR DESCRIPTION
Enable using `supervisorctl stop frontier-squid` and `supervisorctl restart-frontier-squid` from inside the container.