### PR TITLE
Start & stop squid with root script

### DIFF
--- a/start-frontier-squid.sh
+++ b/start-frontier-squid.sh
@@ -2,11 +2,11 @@
 # Wrapper script for starting & stopping frontier squid from supervisord
 
 # stop squid if supervisord sends a TERM signal
-trap "/usr/sbin/fn-local-squid.sh stop" TERM
+trap "/etc/init.d/frontier-squid stop" TERM
 
 # we tell squid to run in the foreground, but by telling the
 #   shell to start it in the background and waiting for it we
 #   prevent the shell from ignoring signals
 export SQUID_START_ARGS="--foreground"
-/usr/sbin/fn-local-squid.sh start &
+/etc/init.d/frontier-squid start &
 wait

--- a/supervisor-frontier-squid.conf
+++ b/supervisor-frontier-squid.conf
@@ -1,4 +1,3 @@
 [program:frontier-squid]
 command=/usr/sbin/start-frontier-squid.sh
 stopwaitsecs=90
-user=squid


### PR DESCRIPTION
Start and stop squid using the /etc/init.d/frontier-squid script as root, which takes care of a few details and fixes a [bug](https://support.opensciencegrid.org/public/tickets/fc3a0dc0ab486c69fbf40e976eab6d54ecad10970785635586321e56c2c4c579) that prevents previous cache data from getting deleted at start time.