### PR TITLE
Remove hack for starting up frontier-squid, it's no longer needed

### DIFF
--- a/60-image-post-init.sh
+++ b/60-image-post-init.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# temporary until https://its.cern.ch/jira/browse/FTAPPDEVEL-172
-sed -i 's/$SQUID$/$SQUID $SQUID_START_ARGS/' /usr/sbin/fn-local-squid.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ RUN rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch && \
                 filebeat && \
     rm -rf /var/cache/yum/*
 
-COPY 60-image-post-init.sh /etc/osg/image-config.d/60-image-post-init.sh
 COPY start-frontier-squid.sh /usr/sbin/
 COPY squid-customize.sh /etc/squid/customize.sh
 COPY customize.d/* /etc/squid/customize.d/


### PR DESCRIPTION
See [SOFTWARE-4542](https://opensciencegrid.atlassian.net/browse/SOFTWARE-4542).  After this is applied there's a warning at boot time 
```
/usr/local/sbin/supervisord_startup.sh: line 4: /etc/osg/image-init.d/*.sh: No such file or directory
```
although I'm not sure what the right thing is to do about that.  It does work and I don't see why a startup script should be required.